### PR TITLE
fix: include missing client/api modules in npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xactions",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xactions",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xactions",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "XActions - The Complete X/Twitter Automation Toolkit. Scrapers, MCP server for AI agents, CLI, and browser scripts. No API required. Open source by @nichxbt. Don't Panic.",
   "homepage": "https://xactions.app",
   "repository": {
@@ -174,6 +174,11 @@
     "thought-leader",
     "algorithm-training",
     "x-algorithm"
+  ],
+  "files": [
+    "src/",
+    "types/",
+    "api/config/"
   ],
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

- Adds `"files"` field to `package.json` so `search.js` and `parsers.js` (and all other `src/client/api/` modules) are included in the published npm package
- Bumps version to 3.1.1
- Reduces npm package size from **128 MB / 3,786 files** to **4 MB / 306 files** by only shipping runtime-necessary directories (`src/`, `types/`, `api/config/`)

Fixes #9
Fixes #11

## Test plan

- [x] `npm pack --dry-run` confirms `src/client/api/search.js` and `src/client/api/parsers.js` are included
- [x] `node -e "import('./src/client/Scraper.js')"` resolves without error
- [x] `node -e "import('./src/client/api/parsers.js')"` resolves without error
- [x] `vitest run` — 871 passed, no new failures (3 pre-existing failures: MCP test uses node:test not vitest, x402 integration tests require running server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)