### PR TITLE
fix: add getPage to toolMap so xeepy tools can access the browser

### DIFF
--- a/src/mcp/local-tools.js
+++ b/src/mcp/local-tools.js
@@ -1336,6 +1336,8 @@ export async function x_client_get_trends() {
 // ============================================================================
 
 export const toolMap = {
+  // Internal helper used by xeepy tools in server.js
+  getPage,
   // Auth
   x_login,
   // Scraping (delegated to scrapers/index.js — single source of truth)


### PR DESCRIPTION
## Summary

- `getPage()` is exported from `local-tools.js` but was missing from the `toolMap` object
- `server.js` line 2228 sets `localTools = tools.toolMap || tools.default || tools` — since `toolMap` exists, it takes priority
- All xeepy tools calling `localTools.getPage()` fail with `"localTools.getPage is not a function"`

One-line fix: add `getPage` to the `toolMap` export.

### Affected tools

Every tool in the `executeXeepyTool` switch that calls `localTools.getPage()`:

`x_quote_tweet`, `x_get_replies`, `x_get_media`, `x_get_recommendations`, `x_get_mentions`, `x_get_quote_tweets`, `x_get_hashtag`, `x_get_likers`, `x_get_retweeters`, `x_auto_follow`, `x_follow_engagers`, `x_auto_comment`, `x_auto_retweet`, `x_detect_bots`, `x_find_influencers`, `x_smart_target`, `x_audience_insights`, `x_engagement_report`, `x_monitor_account`, `x_monitor_keyword`, `x_follower_alerts`, `x_track_engagement`

## Test plan

- [ ] `x_quote_tweet` posts successfully (was failing with getPage error)
- [ ] `x_get_replies` returns replies (was failing with getPage error)
- [ ] Other xeepy tools that call `localTools.getPage()` no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)