### PR TITLE
fix: add getPage to toolMap so xeepy tools can access the browser

### DIFF
--- a/src/mcp/local-tools.js
+++ b/src/mcp/local-tools.js
@@ -1336,6 +1336,8 @@ export async function x_client_get_trends() {
 // ============================================================================
 
 export const toolMap = {
+  // Internal helper used by xeepy tools in server.js
+  getPage,
   // Auth
   x_login,
   // Scraping (delegated to scrapers/index.js — single source of truth)


### PR DESCRIPTION
## Summary

One-line fix. `getPage()` is exported from `local-tools.js` but missing from `toolMap`. Since `server.js` line 2228 sets `localTools = tools.toolMap`, all xeepy tools calling `localTools.getPage()` fail.

Affects: `x_quote_tweet`, `x_get_replies`, `x_get_media`, `x_get_recommendations`, `x_get_mentions`, `x_get_quote_tweets`, and all other `executeXeepyTool` handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)