### PR TITLE
fix(cli): make SIGINT monitor shutdown handler async

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1642,7 +1642,7 @@ program
       console.log(chalk.gray(`   ID: ${monitor.id}`));
 
       // Keep process alive
-      process.on('SIGINT', () => {
+      process.on('SIGINT', async () => {
         const { stopMonitor: stop } = await import('../analytics/reputation.js');
         stop(monitor.id);
         console.log(chalk.yellow('\n🛑 Monitor stopped.'));


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI syntax error in `src/cli/index.js` caused by using `await import(...)` inside a non-async `SIGINT` callback.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] New skill (`skills/*/SKILL.md`)
- [ ] Test fix
- [ ] Other

## Runtime context

- OS: Arch Linux
- Node.js: v20.20.2

## Problem

The CLI failed before startup with:

```bash
SyntaxError: Unexpected reserved word
```

The issue came from this pattern:

```js
process.on('SIGINT', () => {
  const { stopMonitor: stop } = await import('../analytics/reputation.js');
  stop(monitor.id);
  console.log(chalk.yellow('\nMonitor stopped.'));
  process.exit(0);
});
```

## Root cause

`await` was used inside a callback that was not marked `async`.

## Fix

Changed the handler to:

```js
process.on('SIGINT', async () => {
  const { stopMonitor: stop } = await import('../analytics/reputation.js');
  stop(monitor.id);
  console.log(chalk.yellow('\nMonitor stopped.'));
  process.exit(0);
});
```

## Validation

Verified locally with:

```bash
npm run cli -- --help
npm run cli -- tweets paoloanzn --limit 10
```

Both commands worked successfully after the patch.
