### PR TITLE
fix(http): replace retired verify_credentials session check; unwrap GraphQL response data

### DIFF
--- a/src/scrapers/twitter/http/auth.js
+++ b/src/scrapers/twitter/http/auth.js
@@ -18,6 +18,8 @@
 import fs from 'fs/promises';
 import crypto from 'crypto';
 
+import { GRAPHQL, DEFAULT_FEATURES, buildGraphQLUrl } from './endpoints.js';
+
 // ---------------------------------------------------------------------------
 // Bearer token — embedded in Twitter's web client JS bundle (public)
 // Same token used by the-convocation/twitter-scraper, d60/twikit, etc.
@@ -111,6 +113,24 @@ function buildCookieHeader(cookies) {
   return Object.entries(cookies)
     .map(([k, v]) => `${k}=${v}`)
     .join('; ');
+}
+
+/**
+ * Decode X's `twid` cookie ("u%3D<numeric id>" / "u=<numeric id>") into the
+ * numeric user ID it carries.
+ *
+ * @param {string|undefined} raw
+ * @returns {string|null} Numeric user ID, or null if absent/malformed.
+ */
+export function parseTwidCookie(raw) {
+  if (!raw) return null;
+  try {
+    const decoded = raw.startsWith('u=') ? raw : decodeURIComponent(raw);
+    const m = /^u=(\d+)$/.exec(decoded);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -562,6 +582,17 @@ export class TwitterAuth {
   /**
    * Validate the current authenticated session.
    *
+   * X retired the v1.1 `account/verify_credentials.json` endpoint (it now
+   * returns HTTP 404 for every caller), so validation probes a live
+   * authenticated GraphQL query instead. Verified against the live API
+   * (2026-08): an expired/dead cookie gets HTTP 401 from UserByScreenName,
+   * a live one gets 200 — even when the queried account is not visible to
+   * the session. (UserByRestId is Cloudflare-blocked from non-browser
+   * contexts, so it is not usable as a probe.)
+   *
+   * The probe queries a known-public account, so it proves liveness but not
+   * identity; identity is taken from the `twid` cookie when present.
+   *
    * @returns {Promise<{ valid: boolean, user: { id: string, username: string, name: string } | null, reason: string, status?: number }>}
    */
   async validateSession() {
@@ -569,35 +600,53 @@ export class TwitterAuth {
       return { valid: false, user: null, reason: 'Missing auth_token or ct0 cookies' };
     }
 
-    try {
-      const res = await this.#fetch(
-        `${WEB_BASE}/i/api/1.1/account/verify_credentials.json`,
-        {
-          method: 'GET',
-          headers: this.getHeaders(true),
-          redirect: 'manual',
-        },
-      );
+    const twid = parseTwidCookie(this.#cookies.twid);
+    const { queryId, operationName } = GRAPHQL.UserByScreenName;
+    const variables = { screen_name: 'x', withSafetyModeUserFields: true };
 
-      if (!res.ok) {
+    try {
+      const url = buildGraphQLUrl(queryId, operationName, variables, DEFAULT_FEATURES);
+      const res = await this.#fetch(url, {
+        method: 'GET',
+        headers: this.getHeaders(true),
+        redirect: 'manual',
+      });
+
+      if (res.status === 401 || res.status === 403) {
         return {
           valid: false,
           user: null,
-          reason: `verify_credentials returned HTTP ${res.status}`,
+          reason: `GraphQL probe rejected the session (HTTP ${res.status}) — cookies expired`,
+          status: res.status,
+        };
+      }
+
+      if (!res.ok) {
+        // Transient/unknown failure — do not fail login over it; downstream
+        // calls will surface real auth problems themselves.
+        return {
+          valid: true,
+          user: null,
+          reason: `Could not verify session (probe returned HTTP ${res.status}); proceeding with supplied cookies`,
           status: res.status,
         };
       }
 
       const data = await res.json();
-      if (!data.id_str && !data.id) {
-        return { valid: false, user: null, reason: 'Response missing user ID' };
+      const result = data?.data?.user?.result;
+      if (!result || result.__typename !== 'User') {
+        return {
+          valid: true,
+          user: null,
+          reason: 'Probe succeeded but no usable user payload; proceeding with supplied cookies',
+        };
       }
 
-      const user = {
-        id: String(data.id_str ?? data.id),
-        username: data.screen_name ?? '',
-        name: data.name ?? '',
-      };
+      // The probed account is not us — identity comes from the twid cookie
+      // when X supplied one, otherwise callers get a session without a
+      // resolved user object (same shape as the unverifiable paths above).
+      const user = twid ? { id: twid, username: '', name: '' } : null;
+
       return { valid: true, user, reason: 'ok' };
     } catch (err) {
       return { valid: false, user: null, reason: `Network error: ${err.message}` };

--- a/src/scrapers/twitter/http/auth.js
+++ b/src/scrapers/twitter/http/auth.js
@@ -582,16 +582,14 @@ export class TwitterAuth {
   /**
    * Validate the current authenticated session.
    *
-   * X retired the v1.1 `account/verify_credentials.json` endpoint (it now
-   * returns HTTP 404 for every caller), so validation probes a live
-   * authenticated GraphQL query instead. Verified against the live API
-   * (2026-08): an expired/dead cookie gets HTTP 401 from UserByScreenName,
-   * a live one gets 200 — even when the queried account is not visible to
-   * the session. (UserByRestId is Cloudflare-blocked from non-browser
-   * contexts, so it is not usable as a probe.)
+   * X retired v1.1 account/verify_credentials.json (now HTTP 404 for all
+   * callers), so validation probes UserByScreenName GraphQL instead.
+   * Verified live (2026-08): dead cookie -> 401, live cookie -> 200, even
+   * when the queried account is not visible to the session. (UserByRestId
+   * is Cloudflare-blocked from non-browser contexts.)
    *
-   * The probe queries a known-public account, so it proves liveness but not
-   * identity; identity is taken from the `twid` cookie when present.
+   * The probe proves liveness, not identity; identity comes from the
+   * `twid` cookie when present.
    *
    * @returns {Promise<{ valid: boolean, user: { id: string, username: string, name: string } | null, reason: string, status?: number }>}
    */
@@ -622,8 +620,7 @@ export class TwitterAuth {
       }
 
       if (!res.ok) {
-        // Transient/unknown failure — do not fail login over it; downstream
-        // calls will surface real auth problems themselves.
+        // Transient failure: proceed; downstream calls surface real auth errors.
         return {
           valid: true,
           user: null,
@@ -642,9 +639,8 @@ export class TwitterAuth {
         };
       }
 
-      // The probed account is not us — identity comes from the twid cookie
-      // when X supplied one, otherwise callers get a session without a
-      // resolved user object (same shape as the unverifiable paths above).
+      // Identity comes from the twid cookie when X supplied one; otherwise
+      // the session has no resolved user (same shape as unverifiable paths).
       const user = twid ? { id: twid, username: '', name: '' } : null;
 
       return { valid: true, user, reason: 'ok' };

--- a/src/scrapers/twitter/http/client.js
+++ b/src/scrapers/twitter/http/client.js
@@ -273,7 +273,11 @@ export class TwitterHttpClient {
 
     // Extract bottom cursor for pagination (queries only)
     const cursor = this._extractCursor(json);
-    return { data: json, cursor };
+    // X's GraphQL responses wrap their payload in a top-level `data` key;
+    // every consumer of this method reads `response.data.<payload>` expecting
+    // that payload directly (e.g. data.user.result), so unwrap here rather
+    // than making ~20 scraper modules reach through response.data.data.
+    return { data: json?.data ?? null, cursor };
   }
 
   /**

--- a/src/scrapers/twitter/http/client.js
+++ b/src/scrapers/twitter/http/client.js
@@ -273,10 +273,7 @@ export class TwitterHttpClient {
 
     // Extract bottom cursor for pagination (queries only)
     const cursor = this._extractCursor(json);
-    // X's GraphQL responses wrap their payload in a top-level `data` key;
-    // every consumer of this method reads `response.data.<payload>` expecting
-    // that payload directly (e.g. data.user.result), so unwrap here rather
-    // than making ~20 scraper modules reach through response.data.data.
+    // Unwrap X's top-level `data` key: consumers read response.data.<payload>.
     return { data: json?.data ?? null, cursor };
   }
 

--- a/src/scrapers/twitter/http/engagement.js
+++ b/src/scrapers/twitter/http/engagement.js
@@ -262,11 +262,11 @@ export async function followByUsername(client, username) {
     withSafetyModeUserFields: true,
   });
 
-  // graphql() returns { data: rawJson, cursor } for queries
-  const raw = response?.data;
+  // graphql() returns { data: payload, cursor } for queries
+  const payload = response?.data;
   const userId =
-    raw?.data?.user?.result?.rest_id ||
-    raw?.data?.user?.rest_id;
+    payload?.user?.result?.rest_id ||
+    payload?.user?.rest_id;
 
   if (!userId) {
     throw new NotFoundError(`User @${cleanName} not found`);

--- a/tests/http-scraper/auth.test.js
+++ b/tests/http-scraper/auth.test.js
@@ -35,12 +35,12 @@ function mockResponse(body, { status = 200, headers = {}, setCookies = [] } = {}
 
 const VALID_COOKIE_STRING = 'auth_token=abc123; ct0=csrf_tok; twid=u%3D999; guest_id=v1%3A1234';
 
-const VERIFY_CREDENTIALS_RESPONSE = {
-  id: 999,
-  id_str: '999',
-  name: 'Test User',
-  screen_name: 'testuser',
-};
+// The GraphQL probe response shape (data.user.result) — see validateSession.
+const VERIFY_CREDENTIALS_RESPONSE = { data: { user: { result: {
+  __typename: 'User',
+  rest_id: '999',
+  legacy: { name: 'Test User', screen_name: 'testuser' },
+} } } };
 
 // ---------------------------------------------------------------------------
 // 1. Cookie String Parsing
@@ -224,13 +224,17 @@ describe('validateSession', () => {
       mockResponse(VERIFY_CREDENTIALS_RESPONSE),
     );
     const auth = new TwitterAuth({ fetch: fetchMock });
-    auth.setCookies({ auth_token: 'at', ct0: 'ct' });
+    auth.setCookies({ auth_token: 'at', ct0: 'ct', twid: 'u%3D999' });
 
     const result = await auth.validateSession();
 
     expect(result.valid).toBe(true);
-    expect(result.user).toEqual({ id: '999', username: 'testuser', name: 'Test User' });
+    expect(result.user).toEqual({ id: '999', username: '', name: '' });
     expect(result.reason).toBe('ok');
+    // Probe must hit a live GraphQL endpoint, not the retired verify_credentials
+    const calledUrl = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain('/i/api/graphql/');
+    expect(calledUrl).toContain('UserByScreenName');
   });
 
   it('returns invalid when cookies are missing', async () => {
@@ -256,17 +260,31 @@ describe('validateSession', () => {
     expect(result.status).toBe(401);
   });
 
-  it('returns invalid when response has no user ID', async () => {
+  it('returns valid without user when probe payload is not a User', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      mockResponse({ name: 'No ID user' }),
+      mockResponse({ data: {} }),
     );
     const auth = new TwitterAuth({ fetch: fetchMock });
     auth.setCookies({ auth_token: 'at', ct0: 'ct' });
 
     const result = await auth.validateSession();
 
-    expect(result.valid).toBe(false);
-    expect(result.reason).toContain('missing user ID');
+    expect(result.valid).toBe(true);
+    expect(result.user).toBeNull();
+  });
+
+  it('treats unexpected probe status as unverifiable, not invalid', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({}, { status: 500 }),
+    );
+    const auth = new TwitterAuth({ fetch: fetchMock });
+    auth.setCookies({ auth_token: 'at', ct0: 'ct' });
+
+    const result = await auth.validateSession();
+
+    expect(result.valid).toBe(true);
+    expect(result.user).toBeNull();
+    expect(result.reason).toContain('Could not verify');
   });
 
   it('handles network errors gracefully', async () => {
@@ -403,7 +421,8 @@ describe('loginWithCookies', () => {
 
     const user = await auth.loginWithCookies(VALID_COOKIE_STRING);
 
-    expect(user).toEqual({ id: '999', username: 'testuser', name: 'Test User' });
+    // twid=u%3D999 in VALID_COOKIE_STRING supplies the session identity
+    expect(user).toEqual({ id: '999', username: '', name: '' });
     expect(auth.isAuthenticated()).toBe(true);
     expect(auth.getCsrfToken()).toBe('csrf_tok');
   });
@@ -510,7 +529,7 @@ describe('loginWithCredentials', () => {
           return res;
         }
       }
-      if (url.includes('verify_credentials')) {
+      if (url.includes('/i/api/graphql/') && url.includes('UserByScreenName')) {
         return mockResponse(VERIFY_CREDENTIALS_RESPONSE);
       }
       return mockResponse({}, { status: 500 });
@@ -520,7 +539,8 @@ describe('loginWithCredentials', () => {
     const auth = new TwitterAuth({ fetch: fetchMock2 });
     const user = await auth.loginWithCredentials('testuser', 'password123', 'test@example.com');
 
-    expect(user).toEqual({ id: '999', username: 'testuser', name: 'Test User' });
+    // Probe proves liveness but not identity (no twid cookie in the mock flow)
+    expect(user).toEqual({});
     expect(auth.isAuthenticated()).toBe(true);
   });
 
@@ -563,15 +583,15 @@ describe('loginWithCredentials', () => {
           return res;
         }
       }
-      if (url.includes('verify_credentials')) {
+      if (url.includes('/i/api/graphql/') && url.includes('UserByScreenName')) {
         return mockResponse(VERIFY_CREDENTIALS_RESPONSE);
       }
       return mockResponse({}, { status: 500 });
     });
 
     const auth = new TwitterAuth({ fetch: fetchMock });
-    const user = await auth.loginWithCredentials('user', 'pass', 'e@e.com');
-    expect(user.username).toBe('testuser');
+    await auth.loginWithCredentials('user', 'pass', 'e@e.com');
+    expect(auth.isAuthenticated()).toBe(true);
   });
 
   it('handles LoginAcid (email verification) subtask', async () => {
@@ -609,15 +629,15 @@ describe('loginWithCredentials', () => {
           return res;
         }
       }
-      if (url.includes('verify_credentials')) {
+      if (url.includes('/i/api/graphql/') && url.includes('UserByScreenName')) {
         return mockResponse(VERIFY_CREDENTIALS_RESPONSE);
       }
       return mockResponse({}, { status: 500 });
     });
 
     const auth = new TwitterAuth({ fetch: fetchMock });
-    const user = await auth.loginWithCredentials('user', 'pass', 'verify@test.com');
-    expect(user.username).toBe('testuser');
+    await auth.loginWithCredentials('user', 'pass', 'verify@test.com');
+    expect(auth.isAuthenticated()).toBe(true);
   });
 
   it('throws when LoginAcid requires email but none provided', async () => {
@@ -764,7 +784,7 @@ describe('refreshSession', () => {
           return res;
         }
       }
-      if (url.includes('verify_credentials')) {
+      if (url.includes('/i/api/graphql/') && url.includes('UserByScreenName')) {
         return mockResponse(VERIFY_CREDENTIALS_RESPONSE);
       }
       return mockResponse({}, { status: 500 });
@@ -776,8 +796,8 @@ describe('refreshSession', () => {
     await auth.loginWithCredentials('myuser', 'mypass', 'my@email.com');
 
     // Now refresh
-    const user = await auth.refreshSession();
-    expect(user.username).toBe('testuser');
+    await auth.refreshSession();
+    expect(auth.isAuthenticated()).toBe(true);
   });
 
   it('throws AuthError when no credentials stored (cookie-only)', async () => {
@@ -821,7 +841,7 @@ describe('accessors', () => {
     await auth.loginWithCookies(VALID_COOKIE_STRING);
 
     const user = auth.getUser();
-    expect(user).toEqual({ id: '999', username: 'testuser', name: 'Test User' });
+    expect(user).toEqual({ id: '999', username: '', name: '' });
   });
 
   it('getCookieString builds semicolon-separated string', () => {

--- a/tests/http-scraper/benchmark.test.js
+++ b/tests/http-scraper/benchmark.test.js
@@ -21,7 +21,7 @@ import { PROFILE_RESPONSE, mockResponse } from './fixtures/responses.js';
 // ---------------------------------------------------------------------------
 
 /** Strip the outer `data` wrapper — see integration.test.js for rationale */
-const graphqlBody = (fixture) => fixture.data ?? fixture;
+const graphqlBody = (fixture) => fixture;
 
 /**
  * Time how many milliseconds a function takes to execute.

--- a/tests/http-scraper/integration.test.js
+++ b/tests/http-scraper/integration.test.js
@@ -6,10 +6,9 @@
  * functions → parsed output. Fixtures provide realistic Twitter API
  * response shapes.
  *
- * NOTE: client.graphql() wraps raw JSON as { data: json, cursor }.
- * Consumers access response.data.xxx, so the fetch mock must return
- * the INNER part of the Twitter API response (without the outer `data`
- * wrapper). Use `graphqlBody(FIXTURE)` helper to strip it.
+ * NOTE: client.graphql() unwraps the raw JSON's top-level `data` key and
+ * returns { data: payload, cursor }. Consumers access response.data.xxx,
+ * so the fetch mock returns the FULL Twitter API response shape.
  *
  * @see fixtures/responses.js
  * @author nich (@nichxbt)
@@ -74,14 +73,14 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * Strip the outer `data` wrapper from a fixture for fetch-level mocking.
- * client.graphql() adds its own { data: json, cursor } wrapper, so
- * consumers access response.data.xxx = json.xxx.
+ * Fixture passthrough for fetch-level mocking.
+ * client.graphql() now unwraps X's top-level `data` key itself, so mocks
+ * return the full realistic response shape (outer `data` included).
  *
  * @param {object} fixture — Full realistic Twitter API response
- * @returns {object} Inner content suitable for mock fetch json()
+ * @returns {object} Content suitable for mock fetch json()
  */
-const graphqlBody = (fixture) => fixture.data ?? fixture;
+const graphqlBody = (fixture) => fixture;
 
 /**
  * Create an authenticated TwitterHttpClient with a mock fetch.
@@ -327,9 +326,9 @@ describe('Integration: Non-Follower Detection Flow', () => {
 
   it('verifies set comparison is correct with overlapping lists', async () => {
     // Minimal inline test — parse user lists directly
-    const followersInstructions = graphqlBody(FOLLOWERS_RESPONSE)
+    const followersInstructions = FOLLOWERS_RESPONSE.data
       .user.result.timeline.timeline.instructions;
-    const followingInstructions = graphqlBody(FOLLOWING_RESPONSE)
+    const followingInstructions = FOLLOWING_RESPONSE.data
       .user.result.timeline.timeline.instructions;
 
     const followers = parseUserList(followersInstructions);

--- a/tests/http-scraper/session-validation.test.js
+++ b/tests/http-scraper/session-validation.test.js
@@ -1,0 +1,152 @@
+// Copyright (c) 2024-2026 nich (@nichxbt). Licensed under the Apache License, Version 2.0.
+/**
+ * Tests for the endpoint-drift fixes (2026-08):
+ *
+ * 1. validateSession() probes UserByScreenName GraphQL instead of the
+ *    retired /1.1/account/verify_credentials.json (HTTP 404 for all callers).
+ * 2. client.graphql() unwraps X's top-level `data` key so consumers can read
+ *    response.data.<payload> directly.
+ *
+ * All tests use mocked fetch - no real network requests.
+ *
+ * @author mayconfrr
+ * @license MIT
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { TwitterAuth, parseTwidCookie } from '../../src/scrapers/twitter/http/auth.js';
+import { TwitterHttpClient } from '../../src/scrapers/twitter/http/client.js';
+import { GRAPHQL } from '../../src/scrapers/twitter/http/endpoints.js';
+
+/** Build a minimal mock Response. */
+function mockResponse(body, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+const PROBE_BODY = {
+  data: {
+    user: {
+      result: {
+        __typename: 'User',
+        rest_id: '999',
+        legacy: { name: 'Probe Target', screen_name: 'x' },
+      },
+    },
+  },
+};
+
+describe('validateSession probes a live GraphQL endpoint', () => {
+  it('does NOT call the retired verify_credentials.json endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(PROBE_BODY));
+    const auth = new TwitterAuth({ fetch: fetchMock });
+    auth.setCookies({ auth_token: 'at', ct0: 'ct' });
+
+    await auth.validateSession();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('/i/api/graphql/');
+    expect(url).toContain(GRAPHQL.UserByScreenName.queryId);
+    expect(url).not.toContain('verify_credentials');
+  });
+
+  it('treats HTTP 404 from the probe as unverifiable, not dead session', async () => {
+    // verify_credentials used to 404 and fail every login; any non-auth
+    // status must no longer hard-fail validation.
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({}, { status: 404 }));
+    const auth = new TwitterAuth({ fetch: fetchMock });
+    auth.setCookies({ auth_token: 'at', ct0: 'ct' });
+
+    const result = await auth.validateSession();
+
+    expect(result.valid).toBe(true);
+    expect(result.user).toBeNull();
+    expect(result.status).toBe(404);
+  });
+
+  it('rejects an expired cookie on HTTP 401 from the probe', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({}, { status: 401 }));
+    const auth = new TwitterAuth({ fetch: fetchMock });
+    auth.setCookies({ auth_token: 'dead', ct0: 'ct' });
+
+    const result = await auth.validateSession();
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('401');
+  });
+
+  it('rejects a CSRF mismatch on HTTP 403 from the probe', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({}, { status: 403 }));
+    const auth = new TwitterAuth({ fetch: fetchMock });
+    auth.setCookies({ auth_token: 'at', ct0: 'wrong' });
+
+    const result = await auth.validateSession();
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('derives identity from the twid cookie when present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(PROBE_BODY));
+    const auth = new TwitterAuth({ fetch: fetchMock });
+    auth.setCookies({ auth_token: 'at', ct0: 'ct', twid: 'u%3D12345' });
+
+    const result = await auth.validateSession();
+
+    expect(result.valid).toBe(true);
+    expect(result.user).toEqual({ id: '12345', username: '', name: '' });
+  });
+});
+
+describe('parseTwidCookie', () => {
+  it('decodes URL-encoded twid values', () => {
+    expect(parseTwidCookie('u%3D12345')).toBe('12345');
+  });
+
+  it('accepts already-decoded values', () => {
+    expect(parseTwidCookie('u=678')).toBe('678');
+  });
+
+  it('returns null for malformed or missing values', () => {
+    expect(parseTwidCookie('zz')).toBeNull();
+    expect(parseTwidCookie('u=')).toBeNull();
+    expect(parseTwidCookie(undefined)).toBeNull();
+  });
+});
+
+describe('client.graphql() unwraps the response payload', () => {
+  function clientWith(jsonBody) {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => jsonBody,
+      text: async () => JSON.stringify(jsonBody),
+    });
+    return new TwitterHttpClient({ cookies: 'auth_token=a; ct0=b', fetch: fetchImpl, maxRetries: 0 });
+  }
+
+  it("returns X's data payload as .data, not wrapped again", async () => {
+    const raw = { data: { user: { result: { __typename: 'User' } } } };
+    const client = clientWith(raw);
+
+    const response = await client.graphql(GRAPHQL.UserByScreenName.queryId, 'UserByScreenName', {
+      screen_name: 'testuser',
+    });
+
+    // The bug: consumers had to read response.data.data.user.result
+    expect(response.data?.user?.result?.__typename).toBe('User');
+    expect(response.data?.data).toBeUndefined();
+  });
+
+  it('yields null data rather than throwing on an empty payload', async () => {
+    const client = clientWith({});
+    const response = await client.graphql(GRAPHQL.UserByRestId.queryId, 'UserByRestId', { userId: '1' });
+    expect(response.data).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Two defects currently break every authenticated HTTP-scrape flow against the live X API. Both were reproduced and root-caused against live credentials (cookies confirmed valid — raw GraphQL calls succeed with them).

**Defect 1 — dead session validator.** `validateSession()` in `src/scrapers/twitter/http/auth.js` called `/1.1/account/verify_credentials.json`, which X has retired (HTTP 404 for every caller). Since `loginWithCookies()` hard-wires that check, any authenticated use threw `AuthError` before a single fetch.

The validator now probes the `UserByScreenName` GraphQL query against a known-public account. Verified live (2026-08): an expired/dead cookie receives HTTP 401 from that query, a live cookie receives 200 — even when the queried account is not visible to the session. Non-auth failures (404/5xx) are reported as "unverifiable" and no longer fail login; downstream calls still surface real auth problems themselves. Session identity now comes from the `twid` cookie when present (new exported `parseTwidCookie` helper).

`UserByRestId` was tried first as a probe and rejected: it is Cloudflare-blocked (403 HTML) from non-browser contexts regardless of queryId freshness.

**Defect 2 — GraphQL response double-wrap.** `client.graphql()` returned `{ data: rawJSON, cursor }` while every consumer (`profile.js`, `search.js`, `thread.js`, `tweets.js`, `relationships.js`, `media.js`, `dm.js`, `engagement.js` — ~20 sites) reads `response.data.<payload>` expecting X's payload directly. Net effect: `scrapeProfile()` always threw `NotFoundError` because the real path was `response.data.data.user.result`. Fixed at the source — `graphql()` returns `{ data: json?.data ?? null, cursor }`. `engagement.js followByUsername`, which compensated with its own extra `.data` hop, is updated to match.

Live end-to-end after both fixes: `createHttpScraper({ cookies })` + `scrapeProfile('EXM7777')` returns the full profile; garbage cookies are still rejected at login.

This is the same class of breakage as #42 — X endpoint drift silently hard-failing authenticated flows.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] New skill (`skills/*/SKILL.md`)
- [x] Test fix
- [ ] Other

## Runtime context

<!-- Which context does this change affect? -->
- [ ] Browser script (DevTools console on x.com)
- [x] Node.js / CLI / MCP server
- [ ] API server (Express + database)

## Checklist

- [x] Tests pass (`vitest run`) — all 445 http-scraper tests green; the only remaining repo-wide failures are pre-existing `tests/agents/*` cases requiring better-sqlite3 native bindings, unrelated to this change
- [x] No mocks/stubs/fakes introduced (real implementations only)
- [ ] Browser scripts: tested in DevTools console, uses `data-testid` selectors
- [ ] New skills: follows `skills/TEMPLATE.md` format, added to `skills/index.json`
- [ ] Rate limiting: automation has 1–3s delays between actions
- [ ] Author credit present (`// by nichxbt`) in new source files
- [x] ESM imports only (no `require`)
- [x] CLAUDE.md is still accurate (no outdated references)
- [ ] Documentation updated if behavior changed