### PR TITLE
fix(mcp): authenticate the shared browser, and fix five silent-empty result faults

### DIFF
--- a/src/mcp/local-tools.js
+++ b/src/mcp/local-tools.js
@@ -310,9 +310,9 @@ export async function x_get_tweets({ username, limit = 50 }) {
   );
 }
 
-export async function x_search_tweets({ query, limit = 50 }) {
+export async function x_search_tweets({ query, limit = 50, filter = 'latest' }) {
   const { page: pg } = await ensureBrowser();
-  return searchTweets(pg, query, { limit });
+  return searchTweets(pg, query, { limit, filter });
 }
 
 // ============================================================================

--- a/src/mcp/local-tools.js
+++ b/src/mcp/local-tools.js
@@ -57,6 +57,19 @@ async function ensureBrowser() {
     }
     browser = await createBrowser();
     page = await createPage(browser);
+    // Authenticate the singleton browser from the environment. Without this
+    // the whole Puppeteer path runs logged out: x.com serves an empty DOM to
+    // an anonymous session, every selector matches nothing, and the scrape
+    // tools resolve to [] / {} — indistinguishable from an account that
+    // genuinely has no data, with no error for the caller to act on.
+    const envCookie = process.env.XACTIONS_SESSION_COOKIE;
+    if (envCookie) {
+      try {
+        await loginWithCookie(page, envCookie);
+      } catch (err) {
+        console.error('[xactions] browser auto-login failed:', err.message);
+      }
+    }
   }
   return { browser, page };
 }

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -223,6 +223,11 @@ const TOOLS = [
           type: 'number',
           description: 'Maximum results (default: 50)',
         },
+        filter: {
+          type: 'string',
+          enum: ['latest', 'top', 'people', 'photos', 'videos'],
+          description: 'Result ranking (default: latest). Use "top" for the highest-engagement results; "latest" returns the newest, which typically have no engagement yet.',
+        },
         platform: {
           type: 'string',
           enum: ['twitter', 'bluesky', 'mastodon', 'threads'],
@@ -2793,6 +2798,25 @@ async function executePlatformTool() {
 }
 
 /**
+ * Coerce a scraped engagement count to a number.
+ *
+ * The HTTP scraper returns numbers, but DOM-scraped fields have been strings,
+ * sometimes abbreviated ("3.9K"). `+` concatenated those instead of summing,
+ * so every engagement threshold below silently failed to match.
+ *
+ * @param {unknown} value
+ * @returns {number}
+ */
+function toCount(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0;
+  if (typeof value !== 'string') return 0;
+  const match = value.trim().replace(/,/g, '').match(/^([\d.]+)\s*([KMB])?$/i);
+  if (!match) return 0;
+  const scale = { k: 1e3, m: 1e6, b: 1e9 }[(match[2] || '').toLowerCase()] || 1;
+  return Math.round(parseFloat(match[1]) * scale);
+}
+
+/**
  * Normalise a tweet-list result into an array.
  *
  * `localTools.x_search_tweets` and `localTools.x_get_tweets` both resolve to a
@@ -3084,7 +3108,7 @@ async function executeXeepyTool(name, args) {
       const searchResults = await localTools.x_search_tweets?.({ query: args.query, limit: args.limit || 5 });
       const retweeted = [];
       for (const tweet of asTweetList(searchResults)) {
-        if (args.minLikes && tweet.likes < args.minLikes) continue;
+        if (args.minLikes && toCount(tweet.likes) < args.minLikes) continue;
         try {
           await localTools.x_retweet?.({ tweetUrl: tweet.url });
           retweeted.push(tweet.url);
@@ -3139,7 +3163,7 @@ async function executeXeepyTool(name, args) {
         }
         const entry = authorMap.get(username);
         entry.tweetCount++;
-        entry.totalEngagement += (tweet.likes || 0) + (tweet.retweets || 0) + (tweet.replies || 0);
+        entry.totalEngagement += toCount(tweet.likes) + toCount(tweet.retweets) + toCount(tweet.replies);
       }
       
       const influencers = Array.from(authorMap.values())
@@ -3178,7 +3202,15 @@ async function executeXeepyTool(name, args) {
     }
 
     case 'x_crypto_analyze': {
-      const searchResults = await localTools.x_search_tweets?.({ query: args.query, limit: args.limit || 100 });
+      // Rank by 'top' rather than the default 'latest'. The newest tweets for
+      // a ticker have had no time to accumulate engagement, so sampling them
+      // measured sentiment over fresh spam and left topInfluencers — which
+      // requires engagement > 50 — permanently empty.
+      const searchResults = await localTools.x_search_tweets?.({
+        query: args.query,
+        limit: args.limit || 100,
+        filter: 'top',
+      });
       const tweets = asTweetList(searchResults);
       
       let bullish = 0, bearish = 0, neutral = 0;
@@ -3186,7 +3218,7 @@ async function executeXeepyTool(name, args) {
       
       for (const tweet of tweets) {
         const text = (tweet.text || '').toLowerCase();
-        const engagement = (tweet.likes || 0) + (tweet.retweets || 0);
+        const engagement = toCount(tweet.likes) + toCount(tweet.retweets);
         
         if (text.match(/bull|moon|pump|buy|long|breakout|ath|🚀|💎|🔥/)) bullish++;
         else if (text.match(/bear|dump|sell|short|crash|dead|rug|💀|📉/)) bearish++;
@@ -3303,10 +3335,10 @@ async function executeXeepyTool(name, args) {
       let bestTweet = null, bestEngagement = 0;
       
       for (const t of tweetList) {
-        const eng = (t.likes || 0) + (t.retweets || 0) + (t.replies || 0);
-        totalLikes += t.likes || 0;
-        totalRetweets += t.retweets || 0;
-        totalReplies += t.replies || 0;
+        const eng = toCount(t.likes) + toCount(t.retweets) + toCount(t.replies);
+        totalLikes += toCount(t.likes);
+        totalRetweets += toCount(t.retweets);
+        totalReplies += toCount(t.replies);
         if (eng > bestEngagement) { bestEngagement = eng; bestTweet = t; }
       }
       

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -2793,6 +2793,23 @@ async function executePlatformTool() {
 }
 
 /**
+ * Normalise a tweet-list result into an array.
+ *
+ * `localTools.x_search_tweets` and `localTools.x_get_tweets` both resolve to a
+ * plain array, but the handlers below read `.tweets` off the result. That
+ * property is undefined on an array, so each consumer silently saw zero
+ * tweets and reported an empty analysis instead of failing.
+ *
+ * @param {unknown} result
+ * @returns {Array<object>}
+ */
+function asTweetList(result) {
+  if (Array.isArray(result)) return result;
+  if (Array.isArray(result?.tweets)) return result.tweets;
+  return [];
+}
+
+/**
  * Execute xeepy-ported tools (scrapers, follow/unfollow automation, engagement, AI, monitoring)
  * Ported from github.com/nirholas/xeepy — Python → JavaScript
  */
@@ -2964,7 +2981,7 @@ async function executeXeepyTool(name, args) {
       });
       const users = [];
       const seen = new Set();
-      for (const tweet of (searchResults?.tweets || [])) {
+      for (const tweet of asTweetList(searchResults)) {
         if (users.length >= (args.limit || 10)) break;
         const username = tweet.authorUsername || tweet.author;
         if (!username || seen.has(username)) continue;
@@ -2986,7 +3003,7 @@ async function executeXeepyTool(name, args) {
       const engagers = new Set();
       const followed = [];
       // Simplified — follow repliers from recent tweets
-      for (const tweet of (tweets?.tweets || []).slice(0, 5)) {
+      for (const tweet of asTweetList(tweets).slice(0, 5)) {
         if (followed.length >= (args.limit || 10)) break;
         // Would scrape replies for full implementation
       }
@@ -3053,7 +3070,7 @@ async function executeXeepyTool(name, args) {
     case 'x_auto_comment': {
       const searchResults = await localTools.x_search_tweets?.({ query: args.query, limit: args.limit || 5 });
       const commented = [];
-      for (const tweet of (searchResults?.tweets || [])) {
+      for (const tweet of asTweetList(searchResults)) {
         try {
           await localTools.x_reply?.({ tweetUrl: tweet.url, text: args.comment });
           commented.push(tweet.url);
@@ -3066,7 +3083,7 @@ async function executeXeepyTool(name, args) {
     case 'x_auto_retweet': {
       const searchResults = await localTools.x_search_tweets?.({ query: args.query, limit: args.limit || 5 });
       const retweeted = [];
-      for (const tweet of (searchResults?.tweets || [])) {
+      for (const tweet of asTweetList(searchResults)) {
         if (args.minLikes && tweet.likes < args.minLikes) continue;
         try {
           await localTools.x_retweet?.({ tweetUrl: tweet.url });
@@ -3093,8 +3110,9 @@ async function executeXeepyTool(name, args) {
         if (!profile.avatar || profile.avatar.includes('default_profile')) { signals.push('default_avatar'); botScore += 20; }
       }
       
-      if (tweets?.tweets) {
-        const texts = tweets.tweets.map(t => t.text);
+      const botTweets = asTweetList(tweets);
+      if (botTweets.length) {
+        const texts = botTweets.map(t => t.text);
         const uniqueTexts = new Set(texts);
         if (texts.length > 5 && uniqueTexts.size < texts.length * 0.5) {
           signals.push('repetitive_content'); botScore += 30;
@@ -3113,7 +3131,7 @@ async function executeXeepyTool(name, args) {
     case 'x_find_influencers': {
       const searchResults = await localTools.x_search_tweets?.({ query: args.niche, limit: 100 });
       const authorMap = new Map();
-      for (const tweet of (searchResults?.tweets || [])) {
+      for (const tweet of asTweetList(searchResults)) {
         const username = tweet.authorUsername || tweet.author;
         if (!username) continue;
         if (!authorMap.has(username)) {
@@ -3138,7 +3156,7 @@ async function executeXeepyTool(name, args) {
       
       // Extract niche keywords from user's tweets
       const keywords = new Set();
-      for (const tweet of (tweets?.tweets || [])) {
+      for (const tweet of asTweetList(tweets)) {
         const hashtags = tweet.text.match(/#\w+/g) || [];
         hashtags.forEach(h => keywords.add(h));
       }
@@ -3148,7 +3166,7 @@ async function executeXeepyTool(name, args) {
       
       const seen = new Set([args.username]);
       const result = [];
-      for (const tweet of (targets?.tweets || [])) {
+      for (const tweet of asTweetList(targets)) {
         const u = tweet.authorUsername || tweet.author;
         if (!u || seen.has(u)) continue;
         seen.add(u);
@@ -3161,7 +3179,7 @@ async function executeXeepyTool(name, args) {
 
     case 'x_crypto_analyze': {
       const searchResults = await localTools.x_search_tweets?.({ query: args.query, limit: args.limit || 100 });
-      const tweets = searchResults?.tweets || [];
+      const tweets = asTweetList(searchResults);
       
       let bullish = 0, bearish = 0, neutral = 0;
       const influencerMentions = new Map();
@@ -3279,7 +3297,7 @@ async function executeXeepyTool(name, args) {
     case 'x_engagement_report': {
       const profile = await localTools.x_get_profile?.({ username: args.username });
       const tweets = await localTools.x_get_tweets?.({ username: args.username, limit: 50 });
-      const tweetList = tweets?.tweets || [];
+      const tweetList = asTweetList(tweets);
       
       let totalLikes = 0, totalRetweets = 0, totalReplies = 0;
       let bestTweet = null, bestEngagement = 0;
@@ -3322,7 +3340,7 @@ async function executeXeepyTool(name, args) {
           followers: profile?.followers,
           following: profile?.following,
           bio: profile?.bio?.slice(0, 100),
-          latestTweet: latestTweet?.tweets?.[0]?.text?.slice(0, 100),
+          latestTweet: asTweetList(latestTweet)[0]?.text?.slice(0, 100),
           capturedAt: new Date().toISOString(),
         },
         message: `Monitoring started. Compare future snapshots with this baseline to detect changes.`,
@@ -3333,18 +3351,19 @@ async function executeXeepyTool(name, args) {
       const keywords = args.keywords || [];
       const query = keywords.join(' OR ');
       const results = await localTools.x_search_tweets?.({ query, limit: 20 });
+      const matches = asTweetList(results);
       
       return {
         keywords,
         interval: `${args.interval || 10} minutes`,
-        currentMatches: results?.tweets?.length || 0,
-        latestTweets: (results?.tweets || []).slice(0, 5).map(t => ({
+        currentMatches: matches.length,
+        latestTweets: matches.slice(0, 5).map(t => ({
           text: t.text?.slice(0, 200),
           author: t.authorUsername || t.author,
           likes: t.likes,
           url: t.url,
         })),
-        message: `Monitoring ${keywords.length} keywords. ${results?.tweets?.length || 0} current matches found.`,
+        message: `Monitoring ${keywords.length} keywords. ${matches.length} current matches found.`,
       };
     }
 
@@ -3386,7 +3405,7 @@ async function executeXeepyTool(name, args) {
       return {
         username: args.username,
         followers: profile?.followers,
-        recentEngagement: (tweets?.tweets || []).slice(0, 5).map(t => ({
+        recentEngagement: asTweetList(tweets).slice(0, 5).map(t => ({
           text: t.text?.slice(0, 80),
           likes: t.likes,
           retweets: t.retweets,

--- a/src/scrapers/twitter/index.js
+++ b/src/scrapers/twitter/index.js
@@ -312,11 +312,22 @@ export async function scrapeTweets(page, username, options = {}) {
       return Array.from(articles).map((article) => {
         const textEl = article.querySelector('[data-testid="tweetText"]');
         const timeEl = article.querySelector('time');
-        const likesEl = article.querySelector('[data-testid="like"] span span');
-        const retweetsEl = article.querySelector('[data-testid="retweet"] span span');
-        const repliesEl = article.querySelector('[data-testid="reply"] span span');
-        const viewsEl = article.querySelector('a[href*="/analytics"] span span');
         const linkEl = article.querySelector('a[href*="/status/"]');
+
+        // Counts live in each action button's aria-label ("3944 Likes. Like"),
+        // which carries the exact figure. The visible span read before is
+        // abbreviated ("3.9K") and renders empty whenever the count is zero,
+        // so every tweet came back with '0' — and as a string, which then
+        // concatenated instead of summing in the callers. The fixture in
+        // tests/searchSweep.test.js documents this same aria-label shape.
+        const ariaCount = (selector) => {
+          const label = article
+            .querySelector(selector)
+            ?.getAttribute('aria-label');
+          const digits = label?.replace(/,/g, '').match(/\d+/);
+          return digits ? Number(digits[0]) : 0;
+        };
+
         
         const images = Array.from(article.querySelectorAll('[data-testid="tweetPhoto"] img')).map(i => i.src);
         const video = article.querySelector('[data-testid="videoPlayer"]') ? true : false;
@@ -327,10 +338,10 @@ export async function scrapeTweets(page, username, options = {}) {
           id: linkEl?.href?.match(/status\/(\d+)/)?.[1] || null,
           text: textEl?.textContent || null,
           timestamp: timeEl?.getAttribute('datetime') || null,
-          likes: likesEl?.textContent || '0',
-          retweets: retweetsEl?.textContent || '0',
-          replies: repliesEl?.textContent || '0',
-          views: viewsEl?.textContent || null,
+          likes: ariaCount('[data-testid="like"]'),
+          retweets: ariaCount('[data-testid="retweet"]'),
+          replies: ariaCount('[data-testid="reply"]'),
+          views: ariaCount('a[href*="/analytics"]'),
           url: linkEl?.href || null,
           media: {
             images,
@@ -401,14 +412,30 @@ export async function searchTweets(page, query, options = {}) {
         const authorLink = article.querySelector('[data-testid="User-Name"] a[href^="/"]');
         const timeEl = article.querySelector('time');
         const linkEl = article.querySelector('a[href*="/status/"]');
-        const likesEl = article.querySelector('[data-testid="like"] span span');
-        
+
+        // Counts live in each action button's aria-label ("3944 Likes. Like"),
+        // which carries the exact figure. The visible span read before is
+        // abbreviated ("3.9K") and renders empty whenever the count is zero,
+        // so every tweet came back with '0' — and as a string, which then
+        // concatenated instead of summing in the callers. The fixture in
+        // tests/searchSweep.test.js documents this same aria-label shape.
+        const ariaCount = (selector) => {
+          const label = article
+            .querySelector(selector)
+            ?.getAttribute('aria-label');
+          const digits = label?.replace(/,/g, '').match(/\d+/);
+          return digits ? Number(digits[0]) : 0;
+        };
+
         return {
           id: linkEl?.href?.match(/status\/(\d+)/)?.[1] || null,
           text: textEl?.textContent || null,
           author: authorLink?.href?.split('/')[3] || null,
           timestamp: timeEl?.getAttribute('datetime') || null,
-          likes: likesEl?.textContent || '0',
+          likes: ariaCount('[data-testid="like"]'),
+          retweets: ariaCount('[data-testid="retweet"]'),
+          replies: ariaCount('[data-testid="reply"]'),
+          views: ariaCount('a[href*="/analytics"]'),
           url: linkEl?.href || null,
           platform: 'twitter',
         };
@@ -780,12 +807,34 @@ export async function scrapeTrending(page, options = {}) {
   
   const trends = await page.$$eval('[data-testid="trend"]', (els) =>
     els.map((el) => {
-      const spans = el.querySelectorAll('span');
-      const texts = Array.from(spans).map(s => s.innerText).filter(Boolean);
-      const category = texts[0] || '';
-      const topic = texts.find(t => t.startsWith('#') || t.length > 3) || texts[1] || '';
-      const posts = texts.find(t => /posts|tweets/i.test(t)) || '';
-      return { category, topic, posts, platform: 'twitter' };
+      // A trend cell renders as [rank, "·", category, topic, ...context], e.g.
+      // ["4", "·", "Trending in Hong Kong SAR China", "Clara", "Ethan"].
+      // Read it by structure: the first span over three characters long is the
+      // category label ("Only on X · Trending"), not the topic, and index 0 is
+      // the rank — so the old heuristic returned the label as the topic and
+      // the rank as the category.
+      const texts = Array.from(el.querySelectorAll('span'))
+        .map((s) => s.innerText?.trim())
+        .filter((t) => t && t !== '·');
+
+      const rank = /^\d+$/.test(texts[0] || '') ? Number(texts[0]) : null;
+      const categoryIndex = texts.findIndex((t) => /trending/i.test(t));
+      const category = categoryIndex === -1 ? null : texts[categoryIndex];
+
+      // The topic is the span directly after the category label; with no label
+      // present, fall back to the first span that is not the rank.
+      const topic =
+        (categoryIndex === -1
+          ? texts.find((t) => t !== texts[0] || rank === null)
+          : texts[categoryIndex + 1]) || null;
+
+      // X no longer renders a post count in this view, so this is normally
+      // absent. Report null rather than '' so a caller can tell "not shown"
+      // from "zero".
+      const posts =
+        texts.find((t) => /\d[\d.,]*\s*[KMB]?\s+(posts?|tweets?)/i.test(t)) || null;
+
+      return { rank, category, topic, posts, platform: 'twitter' };
     })
   );
   


### PR DESCRIPTION
Fixes #27.

## What does this PR do?

Five faults on the MCP browser path that all present the same way: a tool returns an empty or wrong-shaped result with no error, so a caller cannot tell an unauthenticated session, or a mis-parsed page, from an account that genuinely has no data. #27 diagnosed the first two in April and they are still live on `main`.

Everything below was found and verified against a live account, not read off the source.

### 1. `ensureBrowser()` never authenticated the singleton browser

`src/mcp/local-tools.js:ensureBrowser()` created the shared Puppeteer page but never consumed `XACTIONS_SESSION_COOKIE`, so every tool on that path ran logged out. x.com serves an empty DOM to an anonymous session, so `x_search_tweets`, `x_get_trends`, `x_get_notifications`, `x_get_bookmarks` and `x_get_settings` all returned `[]` / `{}`.

`loginWithCookie` was already imported here, so the fix is to call it after the page is created; a failure is logged rather than swallowed. `ensureHttpScraper()` in the same file already did this correctly, which is why `x_get_profile` and `x_get_tweets` kept working — and why the fault reads as "my cookie expired" rather than an auth-wiring bug. I confirmed the cookie was valid by driving a standalone Puppeteer session with the same `auth_token`, which rendered a fully logged-in `x.com/home`.

### 2. Tweet-list results were read as objects, but they are arrays

`localTools.x_search_tweets` and `localTools.x_get_tweets` both resolve to a plain array. 15 call sites in `executeXeepyTool` read `.tweets` off that result, which is `undefined` on an array — so 12 tools computed their analysis over zero tweets and returned a confident empty answer: `x_auto_follow`, `x_follow_engagers`, `x_auto_comment`, `x_auto_retweet`, `x_detect_bots`, `x_find_influencers`, `x_smart_target`, `x_crypto_analyze`, `x_engagement_report`, `x_monitor_account`, `x_monitor_keyword`, `x_track_engagement`.

Added `asTweetList()`, which accepts either shape, and routed every site through it. #27 reported this for `x_crypto_analyze`; it turned out to affect 11 more.

### 3. `scrapeTrending()` guessed at the DOM and picked the wrong spans

It took index 0 as the category and "the first span longer than three characters" as the topic. A trend cell is actually `[rank, "·", category, topic, ...context]` — e.g. `["4", "·", "Trending in Hong Kong SAR China", "Clara", "Ethan"]` — so every row came back with the rank in `category`, the category label in `topic`, and the real topic discarded:

```json
{ "category": "1", "topic": "Only on X · Trending", "posts": "" }
```

Now read by structure, with `rank` exposed. `posts` was always `''` because X no longer renders a post count in this view (0 of 30 cells had one); it is now `null` so a caller can distinguish "not shown" from "zero".

### 4. Engagement counts were scraped from the abbreviated span, as strings

`searchTweets()` and `scrapeTweets()` read counts from the action button's inner span. That span is abbreviated (`"3.9K"`) and renders **empty** when the count is zero, so `likes` was the string `'0'` for every search result. The exact figure sits in the button's aria-label (`"3944 Likes. Like"`) — the same shape `tests/searchSweep.test.js` already documents in its fixture, and what `scripts/searchSweep.js` already reads. Both scrapers now take it as a number, and `searchTweets` additionally returns `retweets`, `replies` and `views`.

This also fixes the arithmetic downstream: `(tweet.likes || 0) + (tweet.retweets || 0)` on the old string field concatenated (`"929" + 0` → `"9290"`) instead of summing, so no engagement threshold ever matched correctly. Added `toCount()` in `server.js` and routed the four count arithmetic sites through it, so the math is right whichever scraper produced the row.

### 5. `x_crypto_analyze` sampled the newest tweets, which have no engagement

It searched with the default `filter: 'latest'`. For a ticker, the newest tweets have had no time to accumulate engagement, and `topInfluencers` requires `engagement > 50` — so it was **always** empty, and the sentiment was measured over the freshest, spammiest results. It now asks for `'top'`.

`x_search_tweets` gained a `filter` passthrough to make that possible: `searchTweets()` has supported `latest | top | people | photos | videos` all along, and nothing exposed it. It is now in the tool's input schema too.

## Verification

Driven over stdio JSON-RPC against a live account, running `src/mcp/server.js` from this branch:

| Tool | Before | After |
|---|---|---|
| `x_search_tweets {query: "bitcoin"}` | `[]` | real tweets, numeric `likes`/`retweets`/`replies`/`views` |
| `x_get_trends` | `{category: "1", topic: "Only on X · Trending", posts: ""}` | `{rank: 1, category: "Only on X · Trending", topic: "LINGORM ILF FINAL EP", posts: null}` |
| `x_crypto_analyze {query: "BTC"}` | `tweetCount: 0`, `topInfluencers: []` | `tweetCount: 40`, and `saylor` / `cz_binance` / `100trillionUSD` ranked by real engagement |
| `x_monitor_keyword {keywords: ["bitcoin"]}` | `currentMatches: 0` | `currentMatches: 20` + tweets |
| `x_get_notifications` / `x_get_bookmarks` / `x_get_settings` | `[]` / `[]` / `{}` | real data |

Fix 1 was isolated by calling the unpatched `scrapeTrending`/`searchTweets` on one page before and after `loginWithCookie`: `[]` and `[]` before, 5 trends and 3 tweets after. Fixes 3 and 4 were written against a dump of the live DOM (30 trend cells, and search results at both `f=live` and `f=top`) rather than guessed.

## Type of change

- [x] Bug fix

## Runtime context

- [x] Node.js / CLI / MCP server

## Checklist

- [x] Tests pass (`vitest run`) — 1744 passed, 2 failed, 31 skipped, identical before and after this branch. Both failures (`tests/cli/skills.test.js` skill-install, `tests/client/auth/cookieImport.test.js` Firefox `cookies.sqlite`) reproduce on unmodified `main` at 52fbf89, so they are pre-existing and unrelated. `tests/mcp/` is 68/68 green.
- [x] No mocks/stubs/fakes introduced (real implementations only)
- [ ] Browser scripts: n/a — no `scripts/` changes
- [ ] New skills: n/a
- [x] Rate limiting: unchanged; existing `randomDelay()` calls untouched
- [ ] Author credit (`// by nichxbt`): n/a — no new source files
- [x] ESM imports only (no `require`)
- [x] CLAUDE.md still accurate
- [x] Documentation updated if behavior changed — no docs change needed; this restores the behavior the README already documents. Two things worth calling out for release notes, since they are visible shape changes: `x_get_trends` now returns `{rank, category, topic, posts}` with `posts: null` instead of `{category, topic, posts}` with the rank in `category`, and `x_search_tweets` returns numeric counts instead of a `likes` string. Both are corrections, but a consumer parsing the old shapes will notice. Also, the workaround in the wild — calling `x_login` manually each session — is no longer necessary.

## Still open, not fixed here

- `x_get_settings` returns the settings-nav labels (`{"Your account": "Your account", ...}`) rather than actual setting values. It needs its own scraper rather than a parse tweak, so I left it alone.
- `x_get_profile` with `platform: "bluesky"` dispatches to `x_get_profile_multiplatform` and returns an all-null object still tagged `"platform": "twitter"` (also reported in a comment on #27).

Happy to split either into its own issue or follow-up PR.
